### PR TITLE
fix incorrect number of CPUs

### DIFF
--- a/docker_template_agent1.xml
+++ b/docker_template_agent1.xml
@@ -690,7 +690,7 @@ return JSON.stringify(dataout);
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$.cpu_stats.cpu_usage.percpu_usage.length()</params>
+                                    <params>$.cpu_stats.online_cpus</params>
                                 </step>
                             </preprocessing>
                             <master_item>


### PR DESCRIPTION
I've noticed that the number of CPUs is reported incorrectly. The templates reported a value of 120 CPUs, while my VM only had 8 CPUs. This in turn leads to a miscalculation of the CPU usage.

Maybe this is related to changes in more recent versions of Docker. When using Docker CE 24.0.x the stats output is as follows:

```
    "cpu_stats": {
        "cpu_usage": {
            "total_usage": 5011987175932,
            "percpu_usage": [
                640313097341,
                758276357381,
                735510564887,
                687414795232,
                446384594193,
                526247045399,
                650721075830,
                567119645669,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
(and so on...)
```

My assumption: These zeros probably will the theoretically available CPU slots, while the non-zero values represent my 8 CPUs.

So instead of relying on this value, recent versions of Docker provide a value for the number of CPUs:

```
    "cpu_stats": {
...
        "online_cpus": 8,
...
```

My proposal is to use this value instead. :) Works perfectly fine for me on Docker CE 24.0.x and Zabbix 6.0.x.